### PR TITLE
adapted to run examples in OSX 10.9

### DIFF
--- a/examples/demo/dub.json
+++ b/examples/demo/dub.json
@@ -30,9 +30,13 @@
 
     "mainSourceFile": "demo.d",
 
-    "libs-posix": [
+    "libs-linux": [
         "dl",
         "glfw",
+    ],
+
+    "libs-osx": [
+        "glfw3",
     ],
 
     "dependencies": {

--- a/examples/demo/framework/window.d
+++ b/examples/demo/framework/window.d
@@ -83,21 +83,26 @@ Window createWindow(string windowName, WindowMode windowMode = WindowMode.window
     // turn v-sync off.
     glfwSwapInterval(0);
 
-    // ensure the debug output extension is supported
-    enforce(GL_ARB_debug_output || GL_KHR_debug);
+    version(OSX){
+        // GL_ARM_debug_output and GL_KHR_debug are not supported under OS X 10.9.3
+    }
+    else {
+        // ensure the debug output extension is supported
+        enforce(GL_ARB_debug_output || GL_KHR_debug);
 
-    // cast: workaround for 'nothrow' propagation bug (haven't been able to reduce it)
-    auto hookDebugCallback = GL_ARB_debug_output ? glDebugMessageCallbackARB
-                                                 : cast(typeof(glDebugMessageCallbackARB))glDebugMessageCallback;
+        // cast: workaround for 'nothrow' propagation bug (haven't been able to reduce it)
+        auto hookDebugCallback = GL_ARB_debug_output ? glDebugMessageCallbackARB
+                                                     : cast(typeof(glDebugMessageCallbackARB))glDebugMessageCallback;
 
 
-    // hook the debug callback
-    // cast: when using derelict it assumes its nothrow
-    hookDebugCallback(cast(GLDEBUGPROCARB)&glErrorCallback, null);
+        // hook the debug callback
+        // cast: when using derelict it assumes its nothrow
+        hookDebugCallback(cast(GLDEBUGPROCARB)&glErrorCallback, null);
 
-    // enable proper stack tracing support (otherwise we'd get random failures at runtime)
-    glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
-
+        // enable proper stack tracing support (otherwise we'd get random failures at runtime)
+        glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
+    }
+    
     // finally show the window
     glfwShowWindow(window.window);
 


### PR DESCRIPTION
Well, actually this works under OSX 10.9.3, after having installed glfw3:

```
brew tap homebrew/versions
brew install glfw3
```

I'm not sure about the change from 'posix' to 'linux', there's another way for taming dub about that?
Apart that, every example works and no random-crash (yah!)
