### PR TITLE
Update dbox & examples to work with current compilers

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -25,8 +25,7 @@
     ],
 
     "dependencies": {
-        "glad-drey": ">=0.0.2",
-        "dimgui": ">=0.1.7-alpha",
+        "dimgui": ">=1.0.0"
     },
 
     "subPackages": [

--- a/examples/demo/dub.json
+++ b/examples/demo/dub.json
@@ -41,8 +41,6 @@
 
     "dependencies": {
         "dbox": {"path": "../../", "version": "~master"},
-        "glfw-drey": ">=0.0.2",
-        "glwtf-drey": ">=0.0.1",
-        "dimgui": ">=0.1.4-alpha",
+        "dimgui": ">=1.0.0"
     },
 }

--- a/examples/demo/dub.json
+++ b/examples/demo/dub.json
@@ -25,7 +25,7 @@
     "sourceFiles": ["demo.d"],
 
     "sourcePaths": [
-        ".", "framework", "tests"
+        "framework", "tests"
     ],
 
     "mainSourceFile": "demo.d",

--- a/examples/demo/framework/debug_draw.d
+++ b/examples/demo/framework/debug_draw.d
@@ -447,26 +447,26 @@ struct GLRenderPoints
     void Create()
     {
         string vs =
-            "#version 400\n"
-            "uniform mat4 projectionMatrix;\n"
-            "layout(location = 0) in vec2 v_position;\n"
-            "layout(location = 1) in vec4 v_color;\n"
-            "layout(location = 2) in float v_size;\n"
-            "out vec4 f_color;\n"
-            "void main(void)\n"
-            "{\n"
-            "	f_color = v_color;\n"
-            "	gl_Position = projectionMatrix * vec4(v_position, 0.0f, 1.0f);\n"
-            "   gl_PointSize = v_size;\n"
+            "#version 400\n" ~
+            "uniform mat4 projectionMatrix;\n" ~
+            "layout(location = 0) in vec2 v_position;\n" ~
+            "layout(location = 1) in vec4 v_color;\n" ~
+            "layout(location = 2) in float v_size;\n" ~
+            "out vec4 f_color;\n" ~
+            "void main(void)\n" ~
+            "{\n" ~
+            "	f_color = v_color;\n" ~
+            "	gl_Position = projectionMatrix * vec4(v_position, 0.0f, 1.0f);\n" ~
+            "   gl_PointSize = v_size;\n" ~
             "}\n";
 
         string fs =
-            "#version 400\n"
-            "in vec4 f_color;\n"
-            "out vec4 color;\n"
-            "void main(void)\n"
-            "{\n"
-            "	color = f_color;\n"
+            "#version 400\n" ~
+            "in vec4 f_color;\n" ~
+            "out vec4 color;\n" ~
+            "void main(void)\n" ~
+            "{\n" ~
+            "	color = f_color;\n" ~
             "}\n";
 
         m_programId         = sCreateShaderProgram(vs, fs);
@@ -591,24 +591,24 @@ struct GLRenderLines
     void Create()
     {
         string vs =
-            "#version 400\n"
-            "uniform mat4 projectionMatrix;\n"
-            "layout(location = 0) in vec2 v_position;\n"
-            "layout(location = 1) in vec4 v_color;\n"
-            "out vec4 f_color;\n"
-            "void main(void)\n"
-            "{\n"
-            "	f_color = v_color;\n"
-            "	gl_Position = projectionMatrix * vec4(v_position, 0.0f, 1.0f);\n"
+            "#version 400\n" ~
+            "uniform mat4 projectionMatrix;\n" ~
+            "layout(location = 0) in vec2 v_position;\n" ~
+            "layout(location = 1) in vec4 v_color;\n" ~
+            "out vec4 f_color;\n" ~
+            "void main(void)\n" ~
+            "{\n" ~
+            "	f_color = v_color;\n" ~
+            "	gl_Position = projectionMatrix * vec4(v_position, 0.0f, 1.0f);\n" ~
             "}\n";
 
         string fs =
-            "#version 400\n"
-            "in vec4 f_color;\n"
-            "out vec4 color;\n"
-            "void main(void)\n"
-            "{\n"
-            "	color = f_color;\n"
+            "#version 400\n" ~
+            "in vec4 f_color;\n" ~
+            "out vec4 color;\n" ~
+            "void main(void)\n" ~
+            "{\n" ~
+            "	color = f_color;\n" ~
             "}\n";
 
         m_programId         = sCreateShaderProgram(vs, fs);
@@ -719,24 +719,24 @@ struct GLRenderTriangles
     void Create()
     {
         string vs =
-            "#version 400\n"
-            "uniform mat4 projectionMatrix;\n"
-            "layout(location = 0) in vec2 v_position;\n"
-            "layout(location = 1) in vec4 v_color;\n"
-            "out vec4 f_color;\n"
-            "void main(void)\n"
-            "{\n"
-            "	f_color = v_color;\n"
-            "	gl_Position = projectionMatrix * vec4(v_position, 0.0f, 1.0f);\n"
+            "#version 400\n" ~
+            "uniform mat4 projectionMatrix;\n" ~
+            "layout(location = 0) in vec2 v_position;\n" ~
+            "layout(location = 1) in vec4 v_color;\n" ~
+            "out vec4 f_color;\n" ~
+            "void main(void)\n" ~
+            "{\n" ~
+            "	f_color = v_color;\n" ~
+            "	gl_Position = projectionMatrix * vec4(v_position, 0.0f, 1.0f);\n" ~
             "}\n";
 
         string fs =
-            "#version 400\n"
-            "in vec4 f_color;\n"
-            "out vec4 color;\n"
-            "void main(void)\n"
-            "{\n"
-            "	color = f_color;\n"
+            "#version 400\n" ~
+            "in vec4 f_color;\n" ~
+            "out vec4 color;\n" ~
+            "void main(void)\n" ~
+            "{\n" ~
+            "	color = f_color;\n" ~
             "}\n";
 
         m_programId         = sCreateShaderProgram(vs, fs);

--- a/examples/demo/framework/main.d
+++ b/examples/demo/framework/main.d
@@ -75,6 +75,8 @@ Test test;
 Settings settings;
 bool moveCamera;
 b2Vec2 lastp;
+// Scaling for high-resolution displays.
+double mouseXToWindowFactor = 0, mouseYToWindowFactor = 0;
 
 //
 void sCreateUI()
@@ -113,6 +115,8 @@ extern(C) void sResizeWindow(GLFWwindow*, int width, int height)
 {
     g_camera.m_width  = width;
     g_camera.m_height = height;
+    mouseXToWindowFactor = 0;
+    mouseYToWindowFactor = 0;
 }
 
 //
@@ -561,7 +565,7 @@ void runTests()
 
     while (!glfwWindowShouldClose(mainWindow))
     {
-        glfwGetWindowSize(mainWindow, &g_camera.m_width, &g_camera.m_height);
+        glfwGetFramebufferSize(mainWindow, &g_camera.m_width, &g_camera.m_height);
         glViewport(0, 0, g_camera.m_width, g_camera.m_height);
 
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -572,6 +576,21 @@ void runTests()
 
         double xd, yd;
         glfwGetCursorPos(mainWindow, &xd, &yd);
+        // Scale the cursor position for high-resolution displays.
+        if (mouseXToWindowFactor == 0) // need to initialize
+        {
+            int virtualWindowWidth, virtualWindowHeight;
+            glfwGetWindowSize(mainWindow, &virtualWindowWidth, &virtualWindowHeight);
+            if (virtualWindowWidth != 0 && virtualWindowHeight != 0)
+            {
+                int frameBufferWidth, frameBufferHeight;
+                glfwGetFramebufferSize(mainWindow, &frameBufferWidth, &frameBufferHeight);
+                mouseXToWindowFactor = double(frameBufferWidth) / virtualWindowWidth;
+                mouseYToWindowFactor = double(frameBufferHeight) / virtualWindowHeight;
+            }
+        }
+        xd *= mouseXToWindowFactor;
+        yd *= mouseYToWindowFactor;
         int mousex = cast(int)xd;
         int mousey = cast(int)yd;
 

--- a/examples/demo/tests/dynamictreetest.d
+++ b/examples/demo/tests/dynamictreetest.d
@@ -319,7 +319,8 @@ private:
 
     void Query()
     {
-        m_tree.Query(this, m_queryAABB);
+        auto callback = this;
+        m_tree.Query(callback, m_queryAABB);
 
         for (int32 i = 0; i < e_actorCount; ++i)
         {
@@ -341,7 +342,8 @@ private:
         b2RayCastInput input = m_rayCastInput;
 
         // Ray cast against the dynamic tree.
-        m_tree.RayCast(this, input);
+        auto callback = this;
+        m_tree.RayCast(callback, input);
 
         // Brute force ray cast.
         Actor* bruteActor = null;

--- a/examples/hello_world/dub.json
+++ b/examples/hello_world/dub.json
@@ -29,8 +29,6 @@
     "mainSourceFile": "hello_world.d",
 
     "dependencies": {
-        "dbox": {"path": "../../", "version": "~master"},
-        "glfw-drey": ">=0.0.2",
-        "glwtf-drey": ">=0.0.1",
+        "dbox": {"path": "../../", "version": "~master"}
     },
 }

--- a/src/dbox/common/b2settings.d
+++ b/src/dbox/common/b2settings.d
@@ -177,16 +177,23 @@ void b2Log(const(char)* str, ...)
 {
     va_list args;
 
-    version (X86)
+    static if (__VERSION__ <= 2071)
+    {
+        version (X86)
+            va_start(args, str);
+        else
+        version (Win64)
+            va_start(args, str);
+        else
+        version (X86_64)
+            va_start(args, __va_argsave);
+        else
+            static assert(0, "Platform not supported.");
+    }
+    else
+    {
         va_start(args, str);
-    else
-    version (Win64)
-        va_start(args, str);
-    else
-    version (X86_64)
-        va_start(args, __va_argsave);
-    else
-        static assert(0, "Platform not supported.");
+    }
 
     vprintf(str, args);
     va_end(args);


### PR DESCRIPTION
## All
* dub.json: remove glad-drey/glfw-drey dependency & update dimgui to 1.0.0
* __va_argsave was removed in DMD 2.072

## examples/demo
* Implicit string concatenation was disabled in DMD 2.081
* dub sourcePath needed correction to avoid duplicate files
* Some calls needed pass-by-ref
* Make examples/demo work on macOS retina displays